### PR TITLE
Target suitable agents for deploy step

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -9,3 +9,5 @@
 - name: ":heroku: Deploy"
   command: "./script/deploy"
   branches: "main"
+  agents:
+    heroku: true


### PR DESCRIPTION
Occasionally a deploy would fail because the MacStadium agent would pick up the job, and it isn't configured with Heroku deploy credentials.

- resolves https://buildkite.com/thelookoutway/heroku-drain-datadog/builds/181#0184164c-5c3e-4731-9aa6-eee82756a06f