### PR TITLE
Execute deploy job in nix shell

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -7,7 +7,8 @@
 - wait
 
 - name: ":heroku: Deploy"
-  command: "./script/deploy"
+  command: "nix-shell --run ./script/deploy"
   branches: "main"
   agents:
     heroku: true
+    nix: true


### PR DESCRIPTION
Provides predictable Ruby context.

Searched across our repositories with Buildkite pipelines, and wanted to align a few things.