### PR TITLE
Address nix-direnv deprecation warning

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,7 +1,7 @@
 dotenv
 
-if has nix_direnv_watch_file; then
-  nix_direnv_watch_file $(find nix -type f | xargs)
+if has watch_file; then
+  watch_file $(find nix -type f | xargs)
 fi
 
 watch_dir nix

--- a/.envrc
+++ b/.envrc
@@ -1,10 +1,6 @@
 dotenv
 
-if has watch_file; then
-  watch_file $(find nix -type f | xargs)
-fi
-
-watch_dir nix
+watch_file $(find nix -type f | xargs)
 use nix
 
 PATH_add bin


### PR DESCRIPTION
```
direnv: `nix_direnv_watch_file` is deprecated - use `watch_file`
```