### PR TITLE
Rack 3.1.6

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,2 @@
 DRAIN_PASSWORD="secret"
+HEROKU_APP="tlw-heroku-drain-datadog"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GEM
     nio4r (2.7.0)
     puma (6.4.2)
       nio4r (~> 2.0)
-    rack (3.1.3)
+    rack (3.1.6)
     rack-test (2.1.0)
       rack (>= 1.3)
     roda (3.81.0)

--- a/shell.nix
+++ b/shell.nix
@@ -4,6 +4,7 @@ let
   mkBundlerAppDevShell = nixpkgs.callPackage (import sources.bundler-app-dev-shell) {};
 in mkBundlerAppDevShell {
   buildInputs = with nixpkgs; [
+    heroku
     ruby_3_3
   ];
 }


### PR DESCRIPTION
Addresses a Dependabot security alert that failed to generate a pull request.
- https://github.com/thelookoutway/heroku_drain_datadog/security/dependabot/13
- https://github.com/thelookoutway/heroku_drain_datadog/network/updates/851095596