### PR TITLE
Update niv nixpkgs revision (Ruby 3.4.2)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-ruby "3.3.5"
+ruby "3.4.2"
 
 gem "dogstatsd-ruby"
 gem "puma"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,7 +28,9 @@ GEM
     rspec-support (3.13.1)
 
 PLATFORMS
+  arm64-darwin
   ruby
+  x86_64-linux
 
 DEPENDENCIES
   byebug
@@ -40,7 +42,7 @@ DEPENDENCIES
   rspec
 
 RUBY VERSION
-   ruby 3.3.5p100
+   ruby 3.4.2p28
 
 BUNDLED WITH
-   2.5.16
+   2.6.2

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ See `config/default.yml` for a full list of metrics and how they map between Her
 
 ## System Dependencies
 
-* Ruby 3.3.5
+* Ruby 3.4
 * [Heroku Buildpack for DataDog Agent](https://github.com/DataDog/heroku-buildpack-datadog.git)
 
 ## Setup

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2d2a9ddbe3f2c00747398f3dc9b05f7f2ebb0f53",
-        "sha256": "1v6gpivg8mj4qapdp0y5grapnlvlw8xyh5bjahq9i50iidjr3587",
+        "rev": "1750f3c1c89488e2ffdd47cab9d05454dddfb734",
+        "sha256": "1nrwlaxd0f875r2g6v9brrwmxanra8pga5ppvawv40hcalmlccm0",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/2d2a9ddbe3f2c00747398f3dc9b05f7f2ebb0f53.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/1750f3c1c89488e2ffdd47cab9d05454dddfb734.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/shell.nix
+++ b/shell.nix
@@ -5,6 +5,6 @@ let
 in mkBundlerAppDevShell {
   buildInputs = with nixpkgs; [
     heroku
-    ruby_3_3
+    ruby_3_4
   ];
 }


### PR DESCRIPTION
- bump heroku from 9.3.0 to 10.2.0 (major)
- bump ruby from 3.3.5 to 3.4.2 (minor)
- bump bundler from 2.5.16 to 2.6.2 (minor)

Towards https://3.basecamp.com/3653596/buckets/24245485/card_tables/cards/8448763256.