### PR TITLE
Replace Dependabot reviewers with CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# @see https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Site Reliability own this repository
+* @thelookoutway/site-reliability
+
+/.github/ @thelookoutway/site-reliability

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,5 +9,3 @@ updates:
       timezone: "Australia/Brisbane"
     labels:
       - "dependencies"
-    reviewers:
-      - "thelookoutway/site-reliability"


### PR DESCRIPTION
## Highlights
- Why? https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/
- See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners